### PR TITLE
Fix AWS install process

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,8 +40,11 @@ workflows:
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library
   audit-this-step:
+    before_run:
+    - test
     steps:
     - script:
+        title: Audit current step
         inputs:
         - content: |-
             #!/bin/bash

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,6 +24,18 @@ workflows:
         - aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
         - s3_bucket: $AWS_BUCKET
         - s3_filepath: $AWS_FILE_PATH
+    - change-workdir:
+        title: Switch back to root dir
+        description: ''
+        inputs:
+        - path: ./..
+        - is_create_path: true
+    - script:
+        title: Remove temp folder
+        inputs:
+        - content: |-
+            #!/bin/bash
+            rm -rf ./_tmp
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -83,10 +83,23 @@ workflows:
     - audit-this-step
     steps:
     - script:
+        title: Start step lib
         inputs:
         - content: |-
             #!/bin/bash
             set -ex
             bitrise share start -c ${MY_STEPLIB_REPO_FORK_GIT_URL}
+    - script:
+        title: Create new step version
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
             bitrise share create --stepid ${STEP_ID_IN_STEPLIB} --tag ${STEP_GIT_VERION_TAG_TO_SHARE} --git ${STEP_GIT_CLONE_URL}
+    - script:
+        title: Finish process
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
             bitrise share finish

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -22,8 +22,8 @@ workflows:
         inputs:
         - aws_access_key: $AWS_ACCESS_KEY_ID
         - aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
-        - s3_bucket: fw.ci.keychain
-        - s3_filepath: harmony.p12
+        - s3_bucket: $AWS_BUCKET
+        - s3_filepath: $AWS_FILE_PATH
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library

--- a/step.sh
+++ b/step.sh
@@ -113,12 +113,6 @@ if [ ! -e "${expanded_local_path}" ]; then
   exit 1
 fi
 
-
-# if [[ "$aws_region" != "" ]] ; then
-# 	echo_details "AWS region (${aws_region}) specified!"
-# 	export AWS_DEFAULT_REGION="${aws_region}"
-# fi
-
 S3_PATH="s3://$s3_bucket/$s3_filepath"
 export AWS_ACCESS_KEY_ID="${access_key_id}"
 export AWS_SECRET_ACCESS_KEY="${secret_access_key}"
@@ -128,30 +122,15 @@ AWS_SECRET_ACCESS_KEY="$aws_secret_access_key"
 
 echo_info "Downloading file from path: $S3_PATH to $output_location"
 
-if command -v brew >/dev/null 2>&1; then
-  brew install awscli
-else 
-  apt-get update
-  apt-get -y install awscli
+if command -v aws >/dev/null 2>&1; then
+  echo_info "AWS CLI already installed"
+else
+  echo_info "Installing AWS CLI"
+  curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+  unzip awscli-bundle.zip
+  sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 fi
 
 aws s3 cp --only-show-errors $S3_PATH $output_location
 
 echo_info "File downloaded."
-
-# --- Export Environment Variables for other Steps:
-# You can export Environment Variables for other Steps with
-#  envman, which is automatically installed by `bitrise setup`.
-# A very simple example:
-#  envman add --key EXAMPLE_STEP_OUTPUT --value 'the value you want to share'
-# Envman can handle piped inputs, which is useful if the text you want to
-# share is complex and you don't want to deal with proper bash escaping:
-#  cat file_with_complex_input | envman add --KEY EXAMPLE_STEP_OUTPUT
-# You can find more usage examples on envman's GitHub page
-#  at: https://github.com/bitrise-io/envman
-
-#
-# --- Exit codes:
-# The exit code of your Step is very important. If you return
-#  with a 0 exit code `bitrise` will register your Step as "successful".
-# Any non zero exit code will be registered as "failed" by `bitrise`.


### PR DESCRIPTION
This PR stops using `apt-get` or `brew` to install the AWS CLI tool. Instead, defaults to the official AWS scripting. This still uses AWS CLI v1. 